### PR TITLE
Avoid eager creation for CacheRegistry

### DIFF
--- a/src/main/java/com/emaginalabs/cache/AOPCacheGuiceModule.java
+++ b/src/main/java/com/emaginalabs/cache/AOPCacheGuiceModule.java
@@ -3,6 +3,7 @@ package com.emaginalabs.cache;
 import com.codahale.metrics.MetricRegistry;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import com.google.inject.Singleton;
 import com.google.inject.matcher.Matchers;
 import com.emaginalabs.cache.aop.CacheGuiceInterceptor;
 import com.emaginalabs.cache.provider.CacheRegistryImpl;
@@ -28,7 +29,7 @@ public class AOPCacheGuiceModule extends AbstractModule {
     @Override
     protected void configure() {
         bind(CacheConfig.class).toInstance(cacheConfig);
-        bind(CacheRegistry.class).to(CacheRegistryImpl.class).asEagerSingleton();
+        bind(CacheRegistry.class).to(CacheRegistryImpl.class).in(Singleton.class);
         bind(MetricRegistry.class).toInstance(metricRegistry);
         CacheGuiceInterceptor cachingInterceptor = new CacheGuiceInterceptor();
         requestInjection(cachingInterceptor);

--- a/src/main/java/com/emaginalabs/cache/provider/GuavaCacheImpl.java
+++ b/src/main/java/com/emaginalabs/cache/provider/GuavaCacheImpl.java
@@ -55,9 +55,7 @@ public class GuavaCacheImpl implements Cache {
     @Override
     public void invalidate() {
         resultsCache.invalidateAll();
-        resultsCache.cleanUp();
         exceptionsCache.invalidateAll();
-        exceptionsCache.cleanUp();
 
         this.initializeCaches();
     }


### PR DESCRIPTION
# 🎩 Goal
This PR fixes the problem when the guice injector is configured before the cache config is ready to be used. As CacheRegistry is created as Eager Singleton, it won't reload the config once is ready. To fix this situation, the CacheRegistry will be created as a Lazy Singleton.

# ⚙️ Development
* Change the Module to create this a Lazy Singleton
* Speedup the cache invalidation by avoiding cleanUp()

# ✅ Testing
🤖 This PR can be automatically tested 🤖