### PR TITLE
Allow new namespaces

### DIFF
--- a/src/main/java/com/emaginalabs/cache/Cache.java
+++ b/src/main/java/com/emaginalabs/cache/Cache.java
@@ -5,6 +5,10 @@ package com.emaginalabs.cache;
  */
 public interface Cache {
 
+    String getNamespace();
+
+    CacheNamespaceConfig getConfig();
+
     Object get(CachedMethodId key) throws Throwable;
 
     void put(CachedMethodId key, Object value);

--- a/src/main/java/com/emaginalabs/cache/provider/EhCacheImpl.java
+++ b/src/main/java/com/emaginalabs/cache/provider/EhCacheImpl.java
@@ -22,12 +22,27 @@ public class EhCacheImpl implements Cache {
     net.sf.ehcache.Cache resultsCache;
     net.sf.ehcache.Cache exceptionsCache;
 
+    private String namespace;
+    private CacheNamespaceConfig config;
+
     public EhCacheImpl(String namespace, CacheNamespaceConfig config,
                        MetricRegistry metricRegistry, CacheManager cacheManager) {
+        this.namespace = namespace;
+        this.config = config;
         resultsCache = initializeCache(config.getResultCacheSize(), config.getResultTTLInSeconds(),
                 metricRegistry, cacheManager, namespace + "Results");
         exceptionsCache = initializeCache(config.getErrorCacheSize(), config.getErrorTTLInSeconds(),
                 metricRegistry, cacheManager, namespace + "Exceptions");
+    }
+
+    @Override
+    public String getNamespace() {
+        return namespace;
+    }
+
+    @Override
+    public CacheNamespaceConfig getConfig() {
+        return config;
     }
 
     @Override

--- a/src/main/java/com/emaginalabs/cache/provider/GuavaCacheImpl.java
+++ b/src/main/java/com/emaginalabs/cache/provider/GuavaCacheImpl.java
@@ -33,6 +33,16 @@ public class GuavaCacheImpl implements Cache {
     }
 
     @Override
+    public String getNamespace() {
+        return namespace;
+    }
+
+    @Override
+    public CacheNamespaceConfig getConfig() {
+        return config;
+    }
+
+    @Override
     public Object get(CachedMethodId key) throws Throwable {
         Object cachedResult = resultsCache.getIfPresent(key);
         if (cachedResult != null) {

--- a/src/test/java/com/emaginalabs/cache/dummy/DummyCachedMethods.java
+++ b/src/test/java/com/emaginalabs/cache/dummy/DummyCachedMethods.java
@@ -10,6 +10,8 @@ import java.util.UUID;
  */
 public class DummyCachedMethods {
 
+    public final static String NAMESPACE_NON_CONFIGURED_ON_INIT = "NAMESPACE_NON_CONFIGURED_ON_INIT";
+
     @Cached(namespace = CacheConfigBuilder.GUAVA_NAMESPACE)
     public String getCachedUUIDByGuava() {
         return UUID.randomUUID().toString();
@@ -38,6 +40,11 @@ public class DummyCachedMethods {
     @Cached(namespace = CacheConfigBuilder.GUAVA_NAMESPACE, cachedExceptions = {NullPointerException.class})
     public String throwNonCachedException() {
         throw new RuntimeException(UUID.randomUUID().toString());
+    }
+
+    @Cached(namespace = NAMESPACE_NON_CONFIGURED_ON_INIT)
+    public String getCachedUUID() {
+        return UUID.randomUUID().toString();
     }
 
 }

--- a/src/test/java/com/emaginalabs/cache/fixture/CacheConfigBuilder.java
+++ b/src/test/java/com/emaginalabs/cache/fixture/CacheConfigBuilder.java
@@ -2,6 +2,7 @@ package com.emaginalabs.cache.fixture;
 
 import com.emaginalabs.cache.CacheConfig;
 import com.emaginalabs.cache.CacheNamespaceConfig;
+import com.emaginalabs.cache.Cached;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -16,6 +17,7 @@ public class CacheConfigBuilder {
     public static final String GUAVA_NAMESPACE = "GUAVA";
     public static final int GUAVA_TTL = 100;
     public static final int EHCACHE_TTL = 1000;
+    public static final int DEFAULT_TTL = 600;
 
     public static CacheConfig createConfigForNamespace(String namespace) {
         Map<String, CacheNamespaceConfig> configValues = new HashMap<String, CacheNamespaceConfig>();
@@ -40,6 +42,14 @@ public class CacheConfigBuilder {
         guavaConfig.setErrorCacheTtl(GUAVA_TTL);
         guavaConfig.setErrorCacheTimeUnit(TimeUnit.MILLISECONDS);
         configValues.put(GUAVA_NAMESPACE, guavaConfig);
+
+        CacheNamespaceConfig defaultConfig = new CacheNamespaceConfig();
+        defaultConfig.setProvider(CacheNamespaceConfig.CacheProvider.GUAVA);
+        defaultConfig.setResultCacheTtl(DEFAULT_TTL);
+        defaultConfig.setResultCacheTimeUnit(TimeUnit.MILLISECONDS);
+        defaultConfig.setErrorCacheTtl(DEFAULT_TTL);
+        defaultConfig.setErrorCacheTimeUnit(TimeUnit.MILLISECONDS);
+        configValues.put(Cached.DEFAULT_NAMESPACE, defaultConfig);
 
         return new CacheConfig(configValues);
     }


### PR DESCRIPTION
# 📌 References

* Issue: #3 

# 🎩 Goal

* Allow configuring namespaces after the registry is created
* Create new namespaces with default config for non-configured namespaces

# ⚙️ Development
* Update CacheRegistry to create non-defined namespaces on demand.
* Add tests to ensure everything is working.

# ✅ Testing

🤖 This PR can be automatically tested 🤖